### PR TITLE
Autofix: When using live storage, contract address must be set

### DIFF
--- a/src/main/java/it/unipr/EVMLiSA.java
+++ b/src/main/java/it/unipr/EVMLiSA.java
@@ -81,8 +81,11 @@ public class EVMLiSA {
 		Options options = new Options();
 
 		// String parameters
+Option contractAddressOption = new Option("ca", "contract-address", true, "address of the contract for live storage");
 		Option addressOption = new Option("a", "address", true, "address of an Ethereum smart contract");
 		addressOption.setRequired(false);
+contractAddressOption.setRequired(false);
+options.addOption(contractAddressOption);
 		options.addOption(addressOption);
 
 		Option outputOption = new Option("o", "output", true, "output directory path");
@@ -174,7 +177,14 @@ public class EVMLiSA {
 		String dumpAnalysis = cmd.getOptionValue("dump-analysis");
 		boolean dumpStatistics = cmd.hasOption("dump-stats");
 		boolean downloadBytecode = cmd.hasOption("download-bytecode");
-		boolean useStorageLive = cmd.hasOption("use-live-storage");
+boolean useStorageLive = cmd.hasOption("use-live-storage");
+String contractAddress = cmd.getOptionValue("contract-address");
+
+if (useStorageLive && contractAddress == null) {
+    log.error("Contract address is required when using live storage.");
+    formatter.printHelp("help", options);
+    System.exit(1);
+}
 		String filepath = cmd.getOptionValue("filepath");
 		String stackSize = cmd.getOptionValue("stack-size");
 		String stackSetSize = cmd.getOptionValue("stack-set-size");
@@ -230,7 +240,8 @@ public class EVMLiSA {
 		jsonOptions.put("dump-analysis", dumpAnalysis);
 		jsonOptions.put("dump-statistics", dumpStatistics);
 		jsonOptions.put("download-bytecode", downloadBytecode);
-		jsonOptions.put("use-storage-live", useStorageLive);
+jsonOptions.put("use-storage-live", useStorageLive);
+jsonOptions.put("contract-address", contractAddress);
 		jsonOptions.put("filepath", filepath);
 		jsonOptions.put("stack-size", AbstractStack.getStackLimit());
 		jsonOptions.put("stack-set-size", AbstractStackSet.getStackSetLimit());
@@ -276,7 +287,12 @@ public class EVMLiSA {
 		} else
 			BYTECODE_FULLPATH = filepath;
 
-		Program program = EVMFrontend.generateCfgFromFile(BYTECODE_FULLPATH);
+Program program = EVMFrontend.generateCfgFromFile(BYTECODE_FULLPATH);
+
+// Set the contract address in EVMAbstractState if using live storage
+if (useStorageLive) {
+    EVMAbstractState.setContractAddress(contractAddress);
+}
 
 		long start = System.currentTimeMillis();
 		long finish;

--- a/src/main/java/it/unipr/analysis/EVMAbstractState.java
+++ b/src/main/java/it/unipr/analysis/EVMAbstractState.java
@@ -44,7 +44,7 @@ public class EVMAbstractState
 	/**
 	 * The address of the running contract.
 	 */
-	private static String CONTRACT_ADDRESS;
+private static String CONTRACT_ADDRESS = null;
 
 	/**
 	 * The stack memory.
@@ -63,7 +63,11 @@ public class EVMAbstractState
 
 	private final StackElement mu_i;
 
-	private static boolean USE_STORAGE_LIVE = false;
+private static boolean USE_STORAGE_LIVE = false;
+
+public static void setContractAddress(String address) {
+    CONTRACT_ADDRESS = address;
+}
 
 	/**
 	 * Builds the abstract domain.
@@ -1253,7 +1257,7 @@ public class EVMAbstractState
 							if (storage.getKeys().contains(key.getNumber()))
 								valueToPush = valueToPush.lub(storage.getState(key.getNumber()));
 							else {
-								if (USE_STORAGE_LIVE && CONTRACT_ADDRESS != null) {
+                                if (USE_STORAGE_LIVE && CONTRACT_ADDRESS != null) {
 									StackElement valueCached = MyCache.getInstance()
 											.get(Pair.of(CONTRACT_ADDRESS, key.getNumber()));
 


### PR DESCRIPTION
Add a new command line option for contract address, make it required when live storage is enabled, and update the EVMAbstractState initialization to use the provided address. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    